### PR TITLE
Refactor for major performance improvements.

### DIFF
--- a/tallier.go
+++ b/tallier.go
@@ -16,10 +16,10 @@ var configFlag = flag.String("config", "",
 	"read flags from this file; overrides any command line settings")
 
 var interfaceFlag = flag.String("interface", "",
-        "interface to listen for statgrams and status page requests on")
+	"interface to listen for statgrams and status page requests on")
 
 var portFlag = flag.Int("port", 8081,
-        "udp port to listen for statgrams and tcp port to serve status pages")
+	"udp port to listen for statgrams and tcp port to serve status pages")
 
 var numWorkersFlag = flag.Int("numWorkers",
 	int(math.Max(1, float64(runtime.NumCPU()-1))),
@@ -89,7 +89,7 @@ func main() {
 
 	server := tally.NewServer(
 		*interfaceFlag, *portFlag, *numWorkersFlag, *flushIntervalFlag,
-        graphite, harold)
+		graphite, harold)
 
 	err = server.Loop()
 	if err != nil {

--- a/tally/frequency_test.go
+++ b/tally/frequency_test.go
@@ -10,7 +10,7 @@ func fc(key string, value float64) FrequencyCount {
 	c[0].NewBucket()
 	c[0].top.timestamp = time.Unix(0, 0)
 	c.Count(value)
-	return FrequencyCount{key, c}
+	return FrequencyCount{key, &c}
 }
 
 func TestSortedItems(t *testing.T) {
@@ -42,6 +42,19 @@ func TestTrim(t *testing.T) {
 	}
 	fcr.Trim()
 	result := fcr.SortedItems()
+	if s, ok := assertDeepEqual(expected, result); !ok {
+		t.Error(s)
+	}
+
+	for count, key := range []string{"a", "b", "c", "d"} {
+		fcr.Count(key, float64(count))
+	}
+	expected = FrequencyCountSlice{
+		fc("d", 6),
+		fc("c", 4),
+	}
+	fcr.Trim()
+	result = fcr.SortedItems()
 	if s, ok := assertDeepEqual(expected, result); !ok {
 		t.Error(s)
 	}

--- a/tally/multilevel_test.go
+++ b/tally/multilevel_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestCount(t *testing.T) {
-	counter := NewMultilevelCount(time.Minute, time.Hour)
+	counter := *NewMultilevelCount(time.Minute, time.Hour)
 	counter.Count(1)
 	for i := 0; i < len(counter); i++ {
 		if counter[i].Current != 1 {
@@ -17,7 +17,7 @@ func TestCount(t *testing.T) {
 }
 
 func TestRollup(t *testing.T) {
-	counter := NewMultilevelCount(time.Minute, time.Hour,
+	counter := *NewMultilevelCount(time.Minute, time.Hour,
 		time.Duration(24)*time.Hour)
 	for i := 0; i < 3; i++ {
 		counter[i].top.timestamp = time.Now().Add(-counter[i].interval)

--- a/tally/server.go
+++ b/tally/server.go
@@ -56,7 +56,7 @@ func (server *Server) Loop() error {
 	infolog("running")
 	server.snapshot = NewSnapshot()
 	server.snapshot.stringCountIntervals = []time.Duration{
-		time.Minute, time.Hour, time.Duration(24) * time.Hour}
+		time.Minute, time.Hour}
 	server.snapshot.start = time.Now()
 	tick := time.Tick(server.flushInterval)
 	for {

--- a/tally/server.go
+++ b/tally/server.go
@@ -17,6 +17,7 @@ type Server struct {
 	harold        *Harold
 	conn          *net.UDPConn
 	snapshot      *Snapshot
+	lastReport    time.Time
 }
 
 func NewServer(host string, port int, numWorkers int,
@@ -63,6 +64,8 @@ func (server *Server) Loop() error {
 		snapchan <- server.snapshot
 		snapshot := <-snapchan
 		nextStart := time.Now()
+		server.addInternalStats(snapshot)
+		server.lastReport = nextStart
 		for {
 			infolog("sending snapshot with %d stats to graphite",
 				snapshot.NumStats())
@@ -80,4 +83,49 @@ func (server *Server) Loop() error {
 		snapshot.start = nextStart
 	}
 	return errors.New("server loop terminated")
+}
+
+func (server *Server) addInternalStats(snapshot *Snapshot) {
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+
+	snapshot.Report("tallier.mem.alloc", float64(ms.Alloc))
+	snapshot.Report("tallier.mem.total", float64(ms.TotalAlloc))
+	snapshot.Report("tallier.mem.sys", float64(ms.Sys))
+	snapshot.Report("tallier.mem.lookups", float64(ms.Lookups))
+	snapshot.Report("tallier.mem.mallocs", float64(ms.Mallocs))
+	snapshot.Report("tallier.mem.frees", float64(ms.Frees))
+
+	snapshot.Report("tallier.mem.heap.alloc", float64(ms.HeapAlloc))
+	snapshot.Report("tallier.mem.heap.sys", float64(ms.HeapSys))
+	snapshot.Report("tallier.mem.heap.idle", float64(ms.HeapIdle))
+	snapshot.Report("tallier.mem.heap.inuse", float64(ms.HeapInuse))
+	snapshot.Report("tallier.mem.heap.released", float64(ms.HeapReleased))
+	snapshot.Report("tallier.mem.heap.objects", float64(ms.HeapObjects))
+
+	snapshot.Report("tallier.mem.stack.inuse", float64(ms.StackInuse))
+	snapshot.Report("tallier.mem.stack.sys", float64(ms.StackSys))
+	snapshot.Report("tallier.mem.stack.mspaninuse", float64(ms.MSpanInuse))
+	snapshot.Report("tallier.mem.stack.mspansys", float64(ms.MSpanSys))
+	snapshot.Report("tallier.mem.stack.mcacheinuse", float64(ms.MCacheInuse))
+	snapshot.Report("tallier.mem.stack.mcachesys", float64(ms.MCacheSys))
+	snapshot.Report("tallier.mem.stack.buckhashsys", float64(ms.BuckHashSys))
+
+	snapshot.Report("tallier.mem.nextgc", float64(ms.NextGC))
+	snapshot.Report("tallier.mem.lastgc", float64(ms.LastGC))
+	snapshot.Report("tallier.mem.pausetotalns", float64(ms.PauseTotalNs))
+	snapshot.Report("tallier.mem.numgc", float64(ms.NumGC))
+
+	if ms.NumGC > 0 {
+		lastGC := time.Unix(0, int64(ms.LastGC))
+		if lastGC.After(server.lastReport) {
+			snapshot.Report("tallier.mem.pause",
+				float64(ms.PauseNs[(ms.NumGC+255)%256])/1000000000,
+				lastGC)
+		}
+	}
+
+	snapshot.Report("tallier.num_workers", float64(snapshot.numChildren))
+	tot := len(snapshot.counts) + len(snapshot.timings) + len(snapshot.reports) + 1
+	snapshot.Report("tallier.num_stats", float64(tot))
 }

--- a/tally/snapshot.go
+++ b/tally/snapshot.go
@@ -156,9 +156,15 @@ func (snapshot *Snapshot) GraphiteReport() (report []string) {
 }
 
 func (snapshot *Snapshot) Flush() {
-	snapshot.reports = make(map[string]ReportedValue, len(snapshot.reports))
-	snapshot.counts = make(map[string]float64, len(snapshot.counts))
-	snapshot.timings = make(map[string][]float64, len(snapshot.timings))
+	for k, _ := range snapshot.reports {
+		delete(snapshot.reports, k)
+	}
+	for k, _ := range snapshot.counts {
+		delete(snapshot.counts, k)
+	}
+	for k, ts := range snapshot.timings {
+		snapshot.timings[k] = ts[:0]
+	}
 	for _, fcs := range snapshot.stringCounts {
 		fcs.Trim()
 	}

--- a/tally/snapshot_test.go
+++ b/tally/snapshot_test.go
@@ -61,10 +61,7 @@ func TestSnapshots(t *testing.T) {
 func TestGraphiteReport(t *testing.T) {
 	now := time.Now()
 	timestamp := fmt.Sprintf(" %d\n", now.Unix())
-	expected := []string{
-		"stats.tallier.num_stats 0" + timestamp,
-		"stats.tallier.num_workers 0" + timestamp,
-	}
+	expected := []string{}
 
 	snapshot := NewSnapshot()
 	snapshot.start = now
@@ -86,8 +83,6 @@ func TestGraphiteReport(t *testing.T) {
 		format("stats.timers.y.mean", 5.5),
 		"stats.timers.y.count 10" + timestamp,
 		format("stats.timers.y.rate", 1),
-		"stats.tallier.num_stats 2" + timestamp,
-		"stats.tallier.num_workers 1" + timestamp,
 	}
 
 	child := NewSnapshot()

--- a/tally/status.go
+++ b/tally/status.go
@@ -113,7 +113,7 @@ func (stringsPage) getTemplate() string {
   <table>
     <thead>
       <tr>
-        <th>rank</th><th>string</th><th>minute</th><th>hour</th><th>day</th>
+        <th>rank</th><th>string</th><th>minute</th><th>hour</th>
       </tr>
     </thead>
     <tbody>
@@ -123,7 +123,6 @@ func (stringsPage) getTemplate() string {
           <td>{{.key}}</td>
           <td>{{printf "%.2g" .minute.rate}} ({{.minute.total}})</td>
           <td>{{printf "%.2g" .hour.rate}} ({{.hour.total}})</td>
-          <td>{{printf "%.2g" .day.rate}} ({{.day.total}})</td>
         </tr>
       {{end}}
     </tbody>
@@ -174,7 +173,7 @@ func stringPage(req *StatusRequest, key string) {
 		return
 	}
 	items := fcs.SortedItems()
-	levels := []string{"minute", "hour", "day"}
+	levels := []string{"minute", "hour"}
 	data := make([]map[string]interface{}, len(items))
 	for i, item := range items {
 		data[i] = map[string]interface{}{

--- a/tally/status.go
+++ b/tally/status.go
@@ -182,9 +182,10 @@ func stringPage(req *StatusRequest, key string) {
 			"rank": i + 1,
 		}
 		for j, level := range levels {
+			c := (*(item.count))[j+1]
 			data[i][level] = map[string]interface{}{
-				"rate":  item.count[j+1].RatePer(time.Second),
-				"total": item.count[j+1].Current,
+				"rate":  c.RatePer(time.Second),
+				"total": c.Current,
 			}
 		}
 	}


### PR DESCRIPTION
Here's a benchmark of datagram parsing.

Before:

```
N=1, mallocs: 31
N=100, mallocs: 3100
N=10000, mallocs: 310013
N=1000000, mallocs: 31000012
N=2000000, mallocs: 62000000
 2000000              7799 ns/op
```

After:

```
N=1, mallocs: 17
N=100, mallocs: 1010
N=10000, mallocs: 100011
N=1000000, mallocs: 10000009
N=10000000, mallocs: 100000008
10000000              1969 ns/op
```
