### PR TITLE
Upgrade to new harold auth method and allow TLS.

### DIFF
--- a/tallier.go
+++ b/tallier.go
@@ -33,7 +33,7 @@ var graphiteFlag = flag.String("graphite", "",
 	"address of graphite (carbon) server")
 
 var haroldFlag = flag.String("harold", "",
-	"address of harold service (REQUIRES -haroldSecret)")
+	"base url of harold service (REQUIRES -haroldSecret)")
 
 var haroldSecretFlag = flag.String("haroldSecret", "",
 	"secret for authenticating with harold service")

--- a/tally/harold.go
+++ b/tally/harold.go
@@ -3,6 +3,9 @@ package tally
 import (
 	"crypto/hmac"
 	"crypto/sha1"
+	// apparently we need to import this here to make go able to verify
+	// certs properly. see: https://code.google.com/p/go/issues/detail?id=5058
+	_ "crypto/sha512"
 	"errors"
 	"fmt"
 	"net/http"
@@ -11,10 +14,6 @@ import (
 	"strings"
 	"time"
 )
-
-// apparently we need to import this here to make go able to verify
-// certs properly. see: https://code.google.com/p/go/issues/detail?id=5058
-import _ "crypto/sha512"
 
 type HaroldPoster interface {
 	Post(path []string, data map[string]string) (*http.Response, error)

--- a/tally/harold_test.go
+++ b/tally/harold_test.go
@@ -66,18 +66,18 @@ func TestHeartMonitor(t *testing.T) {
 }
 
 func TestMakeUrl(t *testing.T) {
-	harold, err := NewHarold("address", "secret")
+	harold, err := NewHarold("https://host/base", "secret")
 	if err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 
-	expected := "http://address/harold/x/secret"
+	expected := "https://host/base/harold/x"
 	result := harold.makeUrl("x")
 	if expected != result {
 		t.Errorf("expected %v, result was %v", expected, result)
 	}
 
-	expected = "http://address/harold/x/y/z/secret"
+	expected = "https://host/base/harold/x/y/z"
 	result = harold.makeUrl("x", "y", "z")
 	if expected != result {
 		t.Errorf("expected %v, result was %v", expected, result)


### PR DESCRIPTION
This updates the harold configuration in tallier to allow for HTTPS, path prefixes, etc. Additionally, it updates to the new github-like authentication style that harold [recently gained support for](https://github.com/spladug/harold/commit/69f32a2004fb00f3ef1910bb71b7b39e06315483).

:eyeglasses: @rram 

![](http://i.imgur.com/5oO6Sat.jpg)

(anyone else interested in reviewing this? :)
