### PR TITLE
Fix crash bug in statgram parsing and change stats recorded for timers.

### DIFF
--- a/tally/snapshot.go
+++ b/tally/snapshot.go
@@ -145,8 +145,6 @@ func (snapshot *Snapshot) GraphiteReport() (report []string) {
 			timings[int(math.Ceil(0.99*float64(len(timings)))-1)]))
 		report = append(report, makeLine("stats.timers.%s.mean %f", key,
 			sum/float64(len(timings))))
-		report = append(report, makeLine("stats.timers.%s.count %d", key,
-			len(timings)))
 		report = append(report, makeLine("stats.timers.%s.rate %f", key,
 			float64(len(timings))/snapshot.duration.Seconds()))
 	}

--- a/tally/snapshot.go
+++ b/tally/snapshot.go
@@ -141,6 +141,8 @@ func (snapshot *Snapshot) GraphiteReport() (report []string) {
 			timings[len(timings)-1]))
 		report = append(report, makeLine("stats.timers.%s.upper_90 %f", key,
 			timings[int(math.Ceil(0.9*float64(len(timings)))-1)]))
+		report = append(report, makeLine("stats.timers.%s.upper_99 %f", key,
+			timings[int(math.Ceil(0.99*float64(len(timings)))-1)]))
 		report = append(report, makeLine("stats.timers.%s.mean %f", key,
 			sum/float64(len(timings))))
 		report = append(report, makeLine("stats.timers.%s.count %d", key,

--- a/tally/snapshot_test.go
+++ b/tally/snapshot_test.go
@@ -81,6 +81,7 @@ func TestGraphiteReport(t *testing.T) {
 		format("stats.timers.y.lower", 1),
 		format("stats.timers.y.upper", 10),
 		format("stats.timers.y.upper_90", 9),
+		format("stats.timers.y.upper_99", 10),
 		format("stats.timers.y.mean", 5.5),
 		"stats.timers.y.count 10" + timestamp,
 		format("stats.timers.y.rate", 1),

--- a/tally/snapshot_test.go
+++ b/tally/snapshot_test.go
@@ -83,7 +83,6 @@ func TestGraphiteReport(t *testing.T) {
 		format("stats.timers.y.upper_90", 9),
 		format("stats.timers.y.upper_99", 10),
 		format("stats.timers.y.mean", 5.5),
-		"stats.timers.y.count 10" + timestamp,
 		format("stats.timers.y.rate", 1),
 	}
 

--- a/tally/statgram.go
+++ b/tally/statgram.go
@@ -20,6 +20,8 @@ const (
 	STRING
 )
 
+const MAX_LINE_LEN = 1024
+
 type Sample struct {
 	key         string
 	value       float64
@@ -37,7 +39,7 @@ type StatgramParser struct {
 }
 
 func NewStatgramParser() *StatgramParser {
-	return &StatgramParser{make(Statgram, 1024), 0, make([]byte, 1024)}
+	return &StatgramParser{make(Statgram, 1024), 0, make([]byte, MAX_LINE_LEN)}
 }
 
 // ParseStatgram reads samples from the given text, returning a Statgram.
@@ -60,14 +62,23 @@ func (parser *StatgramParser) ParseStatgram(datagram []byte) Statgram {
 			prefixLen, err := strconv.ParseInt(string(line[1:3]), 16, 0)
 			if err == nil && int(prefixLen) <= previousLen {
 				previousLen = int(prefixLen) + len(line) - 3
-				copy(parser.previousBuffer[prefixLen:], line[3:])
-				line = parser.previousBuffer[:previousLen]
+				if previousLen <= MAX_LINE_LEN {
+					copy(parser.previousBuffer[prefixLen:], line[3:])
+					line = parser.previousBuffer[:previousLen]
+				} else {
+					line = nil
+				}
+			} else {
+				line = nil
 			}
 		} else {
 			previousLen = len(line)
 			copy(parser.previousBuffer, line)
 		}
-		parser.ParseStatgramLine(line)
+
+		if line != nil {
+			parser.ParseStatgramLine(line)
+		}
 	}
 	return parser.Statgram[:parser.Length]
 }

--- a/tally/statgram.go
+++ b/tally/statgram.go
@@ -61,10 +61,10 @@ func (parser *StatgramParser) ParseStatgram(datagram []byte) Statgram {
 		if len(line) > 2 && line[0] == '^' {
 			prefixLen, err := strconv.ParseInt(string(line[1:3]), 16, 0)
 			if err == nil && int(prefixLen) <= previousLen {
-				previousLen = int(prefixLen) + len(line) - 3
-				if previousLen <= MAX_LINE_LEN {
+				lineLength := int(prefixLen) + len(line) - 3
+				if lineLength <= MAX_LINE_LEN {
 					copy(parser.previousBuffer[prefixLen:], line[3:])
-					line = parser.previousBuffer[:previousLen]
+					line = parser.previousBuffer[:lineLength]
 				} else {
 					line = nil
 				}
@@ -72,12 +72,14 @@ func (parser *StatgramParser) ParseStatgram(datagram []byte) Statgram {
 				line = nil
 			}
 		} else {
-			previousLen = len(line)
 			copy(parser.previousBuffer, line)
 		}
 
 		if line != nil {
 			parser.ParseStatgramLine(line)
+			previousLen = len(line)
+		} else {
+			previousLen = 0
 		}
 	}
 	return parser.Statgram[:parser.Length]

--- a/tally/statgram_test.go
+++ b/tally/statgram_test.go
@@ -126,6 +126,21 @@ func TestParseStatgram(t *testing.T) {
 	}
 }
 
+func TestLongCompressedStatgramLine(t *testing.T) {
+	expected := Statgram{
+		Sample{key: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", value:1.0, valueType: COUNTER, sampleRate: 1.0},
+		Sample{key: "test", value: 1.0, valueType: COUNTER, sampleRate: 1.0},
+	}
+
+	parser := NewStatgramParser()
+	statgram := parser.ParseStatgram(
+		[]byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:1|c\n^ffbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:1|c\ntest:1|c"))
+
+	if s, ok := assertDeepEqual(expected, statgram); !ok {
+		t.Error(s)
+	}
+}
+
 func BenchmarkParseStatgram(b *testing.B) {
 	bs := []byte("x:1|c:2|c\ny:1|m@0.5:e\ns:0|s|a\\nb\\&c\\\\d\\;e\nz:0.1|c")
 	var ms runtime.MemStats

--- a/tally/statgram_test.go
+++ b/tally/statgram_test.go
@@ -136,7 +136,7 @@ func TestLongCompressedStatgramLine(t *testing.T) {
 	parser := NewStatgramParser()
 	// 255 "a"s plus 769 "b"s is 1024 which will take us over the limit
 	statgram := parser.ParseStatgram(
-		[]byte(strings.Repeat("a", 255) + ":1|c\n^ff" + strings.Repeat("b", 769) + ":1|c\ntest:1|c"))
+		[]byte(strings.Repeat("a", 255) + ":1|c\n^ff" + strings.Repeat("b", 769) + ":1|c\n^02bad:1|c\ntest:1|c"))
 
 	if s, ok := assertDeepEqual(expected, statgram); !ok {
 		t.Error(s)

--- a/tally/statgram_test.go
+++ b/tally/statgram_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -128,13 +129,14 @@ func TestParseStatgram(t *testing.T) {
 
 func TestLongCompressedStatgramLine(t *testing.T) {
 	expected := Statgram{
-		Sample{key: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", value:1.0, valueType: COUNTER, sampleRate: 1.0},
+		Sample{key: strings.Repeat("a", 255), value:1.0, valueType: COUNTER, sampleRate: 1.0},
 		Sample{key: "test", value: 1.0, valueType: COUNTER, sampleRate: 1.0},
 	}
 
 	parser := NewStatgramParser()
+	// 255 "a"s plus 769 "b"s is 1024 which will take us over the limit
 	statgram := parser.ParseStatgram(
-		[]byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa:1|c\n^ffbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb:1|c\ntest:1|c"))
+		[]byte(strings.Repeat("a", 255) + ":1|c\n^ff" + strings.Repeat("b", 769) + ":1|c\ntest:1|c"))
 
 	if s, ok := assertDeepEqual(expected, statgram); !ok {
 		t.Error(s)


### PR DESCRIPTION
Crash: This _might_ be what we're seeing in prod. It's the only bug I could see for sure in this code. I'd be shocked if we are actually seeing keys that long.  Either way, it's a legit bug and it should be fixed now.

Timers: Drop the "count". Add 99th percentile.

:eyeglasses: @kemitche @DorianGray (and anyone else interested in reviewing Go)

cc: @jdubs 
